### PR TITLE
Update LokiRolesConfig for cos-lib coordinator compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops
-cosl < 0.0.24
+cosl
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerApp
 from cosl.coordinated_workers.coordinator import Coordinator
 from ops.model import ModelError
 
-from loki_config import LokiConfig, LokiRolesConfig
+from loki_config import LOKI_ROLES_CONFIG, LokiConfig
 from nginx_config import NginxConfig
 
 # Log messages can be retrieved using juju debug-log
@@ -64,7 +64,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
         )
         self.coordinator = Coordinator(
             charm=self,
-            roles_config=LokiRolesConfig(),
+            roles_config=LOKI_ROLES_CONFIG,
             s3_bucket_name="loki",
             external_url=self.external_url,
             worker_metrics_port=8080,

--- a/src/loki_config.py
+++ b/src/loki_config.py
@@ -7,10 +7,10 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping, Set
+from typing import Any, Dict, Set
 
 import yaml
-from cosl.coordinated_workers.coordinator import Coordinator
+from cosl.coordinated_workers.coordinator import ClusterRolesConfig, Coordinator
 from cosl.coordinated_workers.worker import CERT_FILE, KEY_FILE
 
 logger = logging.getLogger(__name__)
@@ -57,17 +57,12 @@ CHUNKS_DIR = os.path.join(LOKI_DIR, "chunks")
 ACTIVE_INDEX_DIR = os.path.join(LOKI_DIR, "index")
 CACHE_DIR = os.path.join(LOKI_DIR, "index_cache")
 
-
-class LokiRolesConfig:
-    """Define the configuration for Loki roles.
-
-    This object implements the ClusterRolesConfig Protocol.
-    """
-
-    roles: Iterable[str] = ROLES
-    meta_roles: Mapping[str, Iterable[str]] = META_ROLES
-    minimal_deployment: Iterable[str] = MINIMAL_DEPLOYMENT
-    recommended_deployment: Dict[str, int] = RECOMMENDED_DEPLOYMENT
+LOKI_ROLES_CONFIG = ClusterRolesConfig(
+    roles=ROLES,
+    meta_roles=META_ROLES,
+    minimal_deployment=MINIMAL_DEPLOYMENT,
+    recommended_deployment=RECOMMENDED_DEPLOYMENT,
+)
 
 
 class LokiConfig:


### PR DESCRIPTION
# Summary
Coordinator ClusterRoleConfig class has changed and requires loki-coordinator to instantiate the ClusterRoleConfig directly.

# Requirements Before Merge
Requires the following PR:
- [x] [cos-lib](https://github.com/canonical/cos-lib/pull/63)

# Note:
* [static-charm CI](https://github.com/canonical/loki-coordinator-k8s-operator/actions/runs/10529002514/job/29175817544?pr=6) test will fail until the above PR is merged
* [unit CI](https://github.com/canonical/loki-coordinator-k8s-operator/actions/runs/10529154201/job/29176304140?pr=6) test will fail until the above PR is merged
* [lib CI](https://github.com/canonical/loki-coordinator-k8s-operator/actions/runs/10529154201/job/29176309464?pr=6) I assume this is a charmcraft issue not related to this PR