### PR TITLE
Change charmcraft.yaml syntax to 2.x

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,10 +14,13 @@ description: |
 # TODO: Add documentation
 # docs: https://discourse.charmhub.io/t/mimir-coordinator-index/10531
 
-base: ubuntu@24.04
-build-base: ubuntu@24.04  # Optional
-platforms:
-  amd64:
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
 
 parts:
   charm:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops
-cosl
+cosl < 0.0.24
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ develop a new k8s charm using the Operator Framework:
 
 https://discourse.charmhub.io/t/4208
 """
+
 import glob
 import logging
 import os
@@ -25,9 +26,10 @@ from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
+from ops.model import ModelError
+
 from loki_config import LokiConfig, LokiRolesConfig
 from nginx_config import NginxConfig
-from ops.model import ModelError
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,9 +6,10 @@
 import os
 import unittest
 
-from charm import LokiCoordinatorK8SOperatorCharm
 from ops.model import BlockedStatus
 from ops.testing import Harness
+
+from charm import LokiCoordinatorK8SOperatorCharm
 
 
 class TestCharm(unittest.TestCase):


### PR DESCRIPTION
We recently pinned Charmcraft to 2.x causing the CI to fail due to 3.x syntax. Updated to 2.x syntax.
* [PR causing the issue](https://github.com/canonical/observability/pull/205/files)