### PR TITLE
add dns resolver to nginx config

### DIFF
--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -3,6 +3,7 @@
 """Nginx workload."""
 
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
 import crossplane
@@ -275,6 +276,9 @@ class NginxConfig:
                     {"directive": "ssl_certificate_key", "args": [KEY_PATH]},
                     {"directive": "ssl_protocols", "args": ["TLSv1", "TLSv1.1", "TLSv1.2"]},
                     {"directive": "ssl_ciphers", "args": ["HIGH:!aNULL:!MD5"]},  # pyright: ignore
+                    # specify resolver to ensure that if a unit IP changes,
+                    # we reroute to the new one
+                    *self._resolver(custom_resolver=_get_dns_ip_address()),
                     *self._locations(addresses_by_role),
                 ],
             }
@@ -293,3 +297,12 @@ class NginxConfig:
                 *self._locations(addresses_by_role),
             ],
         }
+
+
+def _get_dns_ip_address():
+    """Obtain DNS ip address from /etc/resolv.conf."""
+    resolv = Path("/etc/resolv.conf").read_text()
+    for line in resolv.splitlines():
+        if line.startswith("nameserver"):
+            # assume there's only one
+            return line.split()[1].strip()


### PR DESCRIPTION
Fixes https://github.com/canonical/cos-lib/issues/94

This change tells Nginx to update the IP whenever it changes.
To test:
deploy COS-lite plus Mimir.
refresh tempo worker with any locally packed charm
verify you can ping the /ready endpoint soon (max 5sec) after the new worker service has reported ready.