### PR TITLE
feat: support alert rules

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -50,7 +50,7 @@ parts:
       - curl
       - unzip
     override-pull: |
-      curl -fLo lokitool.zip https://github.com/grafana/loki/releases/latest/download/lokitool-linux-${CRAFT_TARGET_ARCH}.zip
+      curl -fLo lokitool.zip https://github.com/grafana/loki/releases/download/v3.2.1/lokitool-linux-${CRAFT_TARGET_ARCH}.zip
       unzip lokitool.zip && rm lokitool.zip
       mv lokitool-linux-${CRAFT_TARGET_ARCH} lokitool
       chmod +x lokitool

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -43,6 +43,17 @@ parts:
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
       chmod +x cos-tool-*
+  lokitool:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+      - unzip
+    override-pull: |
+      curl -fLo lokitool.zip https://github.com/grafana/loki/releases/latest/download/lokitool-linux-${CRAFT_TARGET_ARCH}.zip
+      unzip lokitool.zip && rm lokitool.zip
+      mv lokitool-linux-${CRAFT_TARGET_ARCH} lokitool
+      chmod +x lokitool
 
 containers:
   nginx:

--- a/src/charm.py
+++ b/src/charm.py
@@ -244,7 +244,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                     "rules",
                     "sync",
                     *rules_file_paths,
-                    f"--address={self.external_url}/loki",
+                    f"--address={self.external_url}",
                     "--id=fake",  # multitenancy is disabled, the default tenant is 'fake'
                 ],
                 encoding="utf-8",

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,7 +79,9 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "s3": "s3",
             },
             nginx_config=NginxConfig().config,
-            workers_config=LokiConfig(alertmanager_urls=self.alertmanager_consumer.get_cluster_info()).config,
+            workers_config=LokiConfig(
+                alertmanager_urls=self.alertmanager_consumer.get_cluster_info()
+            ).config,
             workload_tracing_protocols=["jaeger_thrift_http"],
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,7 +107,8 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             path=f"{external_url.path}/loki/api/v1/push",
         )
 
-        self._set_alerts()
+        if self._nginx_container.can_connect():
+            self._set_alerts()
 
         ######################################
         # === EVENT HANDLER REGISTRATION === #
@@ -217,9 +218,6 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             if isinstance(hashable, str):
                 hashable = hashable.encode("utf-8")
             return hashlib.sha256(hashable).hexdigest()
-
-        if not self._nginx_container.can_connect():
-            return
 
         # Get mimirtool if this is the first execution
         if not self._pull(ALERTS_HASH_PATH):

--- a/src/charm.py
+++ b/src/charm.py
@@ -135,7 +135,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _on_pebble_ready(self, _) -> None:
         """Make sure the `lokitool` binary is in the workload container."""
-        self._get_lokitool()
+        self._push_lokitool()
 
     ######################
     # === PROPERTIES === #
@@ -204,7 +204,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
         return paths
 
-    def _get_lokitool(self):
+    def _push_lokitool(self):
         """Copy the `lokitool` binary to the workload container."""
         with open("lokitool", "rb") as f:
             self._nginx_container.push("/usr/bin/lokitool", source=f, permissions=0o744)
@@ -223,7 +223,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
         # Get mimirtool if this is the first execution
         if not self._pull(ALERTS_HASH_PATH):
-            self._get_lokitool()
+            self._push_lokitool()
 
         loki_alerts = self.loki_provider.alerts
         alerts_hash = sha256(str(loki_alerts))

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,16 +10,15 @@ develop a new k8s charm using the Operator Framework:
 https://discourse.charmhub.io/t/4208
 """
 
-import glob
+import hashlib
 import logging
-import os
-import shutil
 import socket
-from typing import Any
+from typing import Any, Dict, List, Optional, cast
 from urllib.parse import urlparse
 
 import cosl.coordinated_workers.nginx
 import ops
+import yaml
 from charms.alertmanager_k8s.v1.alertmanager_dispatch import AlertmanagerConsumer
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
@@ -28,6 +27,7 @@ from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
 from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
 from ops.model import ModelError
+from ops.pebble import Error as PebbleError
 
 from loki_config import LOKI_ROLES_CONFIG, LokiConfig
 from nginx_config import NginxConfig
@@ -35,9 +35,8 @@ from nginx_config import NginxConfig
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
-NGINX_ORIGINAL_ALERT_RULES_PATH = "./src/prometheus_alert_rules/nginx"
-WORKER_ORIGINAL_ALERT_RULES_PATH = "./src/prometheus_alert_rules/loki_workers"
-CONSOLIDATED_ALERT_RULES_PATH = "./src/prometheus_alert_rules/consolidated_rules"
+RULES_DIR = "/etc/loki-alerts/rules"
+ALERTS_HASH_PATH = "/etc/loki-alerts/alerts.sha256"
 
 
 @trace_charm(
@@ -63,6 +62,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             strip_prefix=True,
             scheme=lambda: urlparse(self.internal_url).scheme,
         )
+        self.alertmanager_consumer = AlertmanagerConsumer(self, relation_name="alertmanager")
         self.coordinator = Coordinator(
             charm=self,
             roles_config=LOKI_ROLES_CONFIG,
@@ -79,7 +79,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "s3": "s3",
             },
             nginx_config=NginxConfig().config,
-            workers_config=LokiConfig().config,
+            workers_config=LokiConfig(alertmanager_urls=self.alertmanager_consumer.get_cluster_info()).config,
             workload_tracing_protocols=["jaeger_thrift_http"],
         )
 
@@ -87,8 +87,6 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             self.coordinator.charm_tracing, cosl.coordinated_workers.nginx.CA_CERT_PATH
         )
 
-        # FIXME: Should AlertmanagerConsumer it be in the Coordinator object?
-        self.alertmanager_consumer = AlertmanagerConsumer(self, relation_name="alertmanager")
         self.grafana_source = GrafanaSourceProvider(
             self,
             source_type="loki",
@@ -97,7 +95,6 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             secure_extra_fields={"httpHeaderValue1": "anonymous"},
             refresh_event=[self.coordinator.cluster.on.changed],
         )
-        self._consolidate_nginx_rules()
 
         external_url = urlparse(self.external_url)
         self.loki_provider = LokiPushApiProvider(
@@ -108,11 +105,14 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             path=f"{external_url.path}/loki/api/v1/push",
         )
 
+        self._set_alerts()
+
         ######################################
         # === EVENT HANDLER REGISTRATION === #
         ######################################
         self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+        self.framework.observe(self.on.nginx_pebble_ready, self._on_pebble_ready)
 
     ##########################
     # === EVENT HANDLERS === #
@@ -130,6 +130,10 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
         This event refreshes the PrometheusRemoteWriteProvider address.
         """
         logger.info("Ingress for app revoked")
+
+    def _on_pebble_ready(self, _) -> None:
+        """Make sure the `lokitool` binary is in the workload container."""
+        self._get_lokitool()
 
     ######################
     # === PROPERTIES === #
@@ -162,12 +166,80 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
     # === UTILITY METHODS === #
     ###########################
 
-    # FIXME: Move the alert_rules handling to Coordinator
-    def _consolidate_nginx_rules(self):
-        os.makedirs(CONSOLIDATED_ALERT_RULES_PATH, exist_ok=True)
-        os.makedirs(CONSOLIDATED_ALERT_RULES_PATH, exist_ok=True)
-        for filename in glob.glob(os.path.join(NGINX_ORIGINAL_ALERT_RULES_PATH, "*.*")):
-            shutil.copy(filename, f"{CONSOLIDATED_ALERT_RULES_PATH}/")
+    def _pull(self, path: str) -> Optional[str]:
+        """Pull file from container (without raising pebble errors).
+
+        Returns:
+            File contents if exists; None otherwise.
+        """
+        try:
+            return cast(str, self._nginx_container.pull(path, encoding="utf-8").read())
+        except (FileNotFoundError, PebbleError):
+            # Drop FileNotFoundError https://github.com/canonical/operator/issues/896
+            return None
+
+    def _push(self, path: str, contents: Any):
+        """Push file to container, creating subdirs as necessary."""
+        self._nginx_container.push(path, contents, make_dirs=True, encoding="utf-8")
+
+    def _push_alert_rules(self, alerts: Dict[str, Any]) -> List[str]:
+        """Pushes alert rules from a rules file to the nginx container.
+
+        Args:
+            alerts: a dictionary of alert rule files, fetched from
+                either a metrics consumer or a remote write provider.
+        """
+        paths = []
+        for topology_identifier, rules_file in alerts.items():
+            filename = f"juju_{topology_identifier}.rules"
+            path = f"{RULES_DIR}/{filename}"
+
+            rules = yaml.safe_dump(rules_file)
+
+            self._push(path, rules)
+            paths.append(path)
+            logger.debug("Updated alert rules file %s", filename)
+
+        return paths
+
+    def _get_lokitool(self):
+        """Copy the `lokitool` binary to the workload container."""
+        with open("lokitool", "rb") as f:
+            self._nginx_container.push("/usr/bin/lokitool", source=f, permissions=0o744)
+
+    def _set_alerts(self):
+        """Create alert rule files for all Loki consumers."""
+
+        def sha256(hashable: Any) -> str:
+            """Use instead of the builtin hash() for repeatable values."""
+            if isinstance(hashable, str):
+                hashable = hashable.encode("utf-8")
+            return hashlib.sha256(hashable).hexdigest()
+
+        # Get mimirtool if this is the first execution
+        if not self._pull(ALERTS_HASH_PATH):
+            self._get_lokitool()
+
+        loki_alerts = self.loki_provider.alerts
+        alerts_hash = sha256(str(loki_alerts))
+        alert_rules_changed = alerts_hash != self._pull(ALERTS_HASH_PATH)
+
+        if alert_rules_changed:
+            # Update the alert rules files on disk
+            self._nginx_container.remove_path(RULES_DIR, recursive=True)
+            rules_file_paths: List[str] = self._push_alert_rules(loki_alerts)
+            self._push(ALERTS_HASH_PATH, alerts_hash)
+            # Push the alert rules to the Mimir cluster (persisted in s3)
+            self._nginx_container.pebble.exec(
+                [
+                    "lokitool",
+                    "rules",
+                    "sync",
+                    *rules_file_paths,
+                    f"--address={self.external_url}",
+                    "--id=anonymous",  # multitenancy is disabled, the default tenant is 'anonymous'
+                ]
+            )
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -235,7 +235,9 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             rules_file_paths: List[str] = self._push_alert_rules(loki_alerts)
             self._push(ALERTS_HASH_PATH, alerts_hash)
             # Push the alert rules to the Mimir cluster (persisted in s3)
-            logger.info(f"lokitool rules sync {' '.join(rules_file_paths)} --address={self.external_url}/loki --id=fake")
+            logger.info(
+                f"lokitool rules sync {' '.join(rules_file_paths)} --address={self.external_url}/loki --id=fake"
+            )
             lokitool_output = self._nginx_container.pebble.exec(
                 [
                     "lokitool",

--- a/src/loki_config.py
+++ b/src/loki_config.py
@@ -7,7 +7,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Tuple, Set
+from typing import Any, Dict, Set, Tuple
 
 import yaml
 from cosl.coordinated_workers.coordinator import ClusterRolesConfig, Coordinator
@@ -225,7 +225,6 @@ class LokiConfig:
             # "enable_api": True,
             # "storage": {"local": {"directory": str(self._root_data_dir / "data-alerts")}},
             # "ring": {"kvstore": {"store": "memberlist"}},
-
         }
 
     def _schema_config(self) -> Dict[str, Any]:

--- a/src/loki_config.py
+++ b/src/loki_config.py
@@ -70,7 +70,7 @@ class LokiConfig:
 
     def __init__(
         self,
-        alertmanager_urls: Set[str],
+        alertmanager_urls: Set[str] = set(),
         root_data_dir: Path = Path("/data"),
         recovery_data_dir: Path = Path("/recovery-data"),
     ):

--- a/src/loki_config.py
+++ b/src/loki_config.py
@@ -220,10 +220,11 @@ class LokiConfig:
         return {
             "alertmanager_url": ",".join(sorted(self._alertmanager_urls)),
             "external_url": coordinator._external_url,
-            "rule_path": str(self._root_data_dir / "data-ruler"),
-            "enable_api": True,
-            "storage": {"local": {"directory": str(self._root_data_dir / "data-alerts")}},
-            "ring": {"kvstore": {"store": "memberlist"}},
+            # TODO: remove these, for now trying to make it work
+            # "rule_path": str(self._root_data_dir / "data-ruler"),
+            # "enable_api": True,
+            # "storage": {"local": {"directory": str(self._root_data_dir / "data-alerts")}},
+            # "ring": {"kvstore": {"store": "memberlist"}},
 
         }
 

--- a/src/loki_config.py
+++ b/src/loki_config.py
@@ -130,9 +130,7 @@ class LokiConfig:
                 1 if backend_scale < REPLICATION_MIN_WORKERS else DEFAULT_REPLICATION
             ),
             "compactor_grpc_address": coordinator._external_url,
-            "storage": {
-                "s3": self._s3_storage_config(coordinator)
-            }
+            "storage": {"s3": self._s3_storage_config(coordinator)},
         }
 
     def _compactor_config(self, retention_period: int) -> Dict[str, Any]:

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -70,7 +70,7 @@ LOCATIONS_BACKEND: List[Dict] = [
     },
     {
         "directive": "location",
-        "args": ["=", "/prometheus/api/v1/rules"],
+        "args": ["=", "/prometheus"],
         "block": [
             {
                 "directive": "proxy_pass",

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -57,6 +57,39 @@ LOCATIONS_WRITE: List[Dict] = [
     },
 ]
 
+LOCATIONS_BACKEND: List[Dict] = [
+    {
+        "directive": "location",
+        "args": ["=", "/loki/api/v1/rules"],
+        "block": [
+            {
+                "directive": "proxy_pass",
+                "args": ["http://backend"],
+            },
+        ],
+    },
+    {
+        "directive": "location",
+        "args": ["=", "/prometheus/api/v1/rules"],
+        "block": [
+            {
+                "directive": "proxy_pass",
+                "args": ["http://backend"],
+            },
+        ],
+    },
+    {
+        "directive": "location",
+        "args": ["=", "/api/v1/rules"],
+        "block": [
+            {
+                "directive": "proxy_pass",
+                "args": ["http://backend/loki/api/v1/rules"],
+            },
+        ],
+    },
+]
+
 # Locations shared by all the workers, regardless of the role
 LOCATIONS_WORKER: List[Dict] = [
     {
@@ -224,10 +257,12 @@ class NginxConfig:
         nginx_locations = LOCATIONS_BASIC.copy()
         roles = addresses_by_role.keys()
 
-        if "read" in roles:
-            nginx_locations.extend(LOCATIONS_READ)
         if "write" in roles:
             nginx_locations.extend(LOCATIONS_WRITE)
+        if "backend" in roles:
+            nginx_locations.extend(LOCATIONS_BACKEND)
+        if "read" in roles:
+            nginx_locations.extend(LOCATIONS_READ)
         if roles:
             nginx_locations.extend(LOCATIONS_WORKER)
         return nginx_locations

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,25 +1,54 @@
-# Copyright 2024 Ubuntu
-# See LICENSE file for licensing details.
-#
-# Learn more about testing at: https://juju.is/docs/sdk/testing
+from unittest.mock import MagicMock, patch
 
-import os
-import unittest
+import pytest as pytest
+from cosl.coordinated_workers.coordinator import Coordinator
 
-from ops.model import BlockedStatus
-from ops.testing import Harness
-
-from charm import LokiCoordinatorK8SOperatorCharm
+from src.loki_config import (
+    LOKI_ROLES_CONFIG,
+    MINIMAL_DEPLOYMENT,
+    RECOMMENDED_DEPLOYMENT,
+)
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        os.environ["JUJU_VERSION"] = "3.0.3"
-        self.harness = Harness(LokiCoordinatorK8SOperatorCharm)
-        self.harness.set_can_connect("nginx", True)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin_with_initial_hooks()
+@patch("cosl.coordinated_workers.coordinator.Coordinator.__init__", return_value=None)
+@pytest.mark.parametrize(
+    "roles, expected",
+    (
+        ({"querier": 1}, False),
+        ({"distributor": 1}, False),
+        ({"distributor": 1, "ingester": 1}, False),
+        ({role: 1 for role in MINIMAL_DEPLOYMENT}, True),
+        (RECOMMENDED_DEPLOYMENT, True),
+    ),
+)
+def test_coherent(mock_coordinator, roles, expected):
+    mc = Coordinator(None, None, "", "", 0, None, None, None)
+    cluster_mock = MagicMock()
+    cluster_mock.gather_roles = MagicMock(return_value=roles)
+    mc.cluster = cluster_mock
+    mc._is_coherent = None
+    mc.roles_config = LOKI_ROLES_CONFIG
 
-    def test_simple(self):
-        self.harness.evaluate_status()
-        self.assertIsInstance(self.harness.charm.unit.status, BlockedStatus)
+    assert mc.is_coherent is expected
+
+
+@patch("cosl.coordinated_workers.coordinator.Coordinator.__init__", return_value=None)
+@pytest.mark.parametrize(
+    "roles, expected",
+    (
+        ({"query-frontend": 1}, False),
+        ({"distributor": 1}, False),
+        ({"distributor": 1, "ingester": 1}, False),
+        ({role: 1 for role in MINIMAL_DEPLOYMENT}, False),
+        (RECOMMENDED_DEPLOYMENT, True),
+    ),
+)
+def test_recommended(mock_coordinator, roles, expected):
+    mc = Coordinator(None, None, "", "", 0, None, None, None)
+    cluster_mock = MagicMock()
+    cluster_mock.gather_roles = MagicMock(return_value=roles)
+    mc.cluster = cluster_mock
+    mc._is_recommended = None
+    mc.roles_config = LOKI_ROLES_CONFIG
+
+    assert mc.is_recommended is expected

--- a/tests/unit/test_loki_config.py
+++ b/tests/unit/test_loki_config.py
@@ -94,7 +94,7 @@ def test_build_common_config(loki_config, coordinator, addresses_by_role, replic
                 },
                 "s3forcepathstyle": True,
             }
-        }
+        },
     }
     assert common_config == expected_config_http
 

--- a/tests/unit/test_loki_config.py
+++ b/tests/unit/test_loki_config.py
@@ -79,6 +79,22 @@ def test_build_common_config(loki_config, coordinator, addresses_by_role, replic
         "path_prefix": "/loki",
         "replication_factor": replication,
         "compactor_grpc_address": coordinator._external_url,
+        "storage": {
+            "s3": {
+                "bucketnames": "your_bucket",
+                "endpoint": "s3.com:port",
+                "region": "your_region",
+                "access_key_id": "your_access_key",
+                "secret_access_key": "your_secret_key",
+                "insecure": "true",
+                "http_config": {
+                    "idle_conn_timeout": "90s",
+                    "response_header_timeout": "0s",
+                    "insecure_skip_verify": False,
+                },
+                "s3forcepathstyle": True,
+            }
+        }
     }
     assert common_config == expected_config_http
 


### PR DESCRIPTION
## Issue

Closes #21.

## Solution

The alertmanager relation was already in place. This PR follows a similar approach to https://github.com/canonical/mimir-coordinator-k8s-operator/pull/89.

## To-do

- [x] Solve the `/ruler` API not working.

---

I'm struggling to get the alertmaanger relation to work properly. I'm currently stuck on the `ruler` being unresponsive: pinging `/ruler/ring` on the worker (via the coordinator or on the workere itself) returns 404, unlike `/distributor/ring` and `/compactor/ring`. This happens regaardless of what roles are set on the worker (`all`, `all,ruler`, `read,write,backend`, etc).