### PR TITLE
Implement grafana_datasource_exchange

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -142,6 +142,11 @@ provides:
     description: |
       The coordinator provides scrape jobs for itself and for the workers.
 
+  send-datasource:
+    interface: grafana_datasource_exchange
+    description: |
+      Integration to share with other COS components this charm's datasources, and receive theirs.
+
 config:
   options:
     ingestion-rate-mb:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -162,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 24
 
 logger = logging.getLogger(__name__)
 
@@ -432,13 +432,22 @@ class GrafanaSourceProvider(Object):
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application names to unit names to datasource uids.
+        Returns a mapping from remote application UIDs to unit names to datasource uids.
         """
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
+            app_databag = rel.data[rel.app]
+            grafana_uid = app_databag.get("grafana_uid")
+            if not grafana_uid:
+                logger.warning(
+                    "remote end is using an old grafana_datasource interface: "
+                    "`grafana_uid` field not found."
+                )
+                continue
+
+            uids[grafana_uid] = json.loads(app_databag.get("datasource_uids", "{}"))
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:
@@ -568,6 +577,14 @@ class GrafanaSourceConsumer(Object):
 
         Assumes only leader unit will call this method
         """
+        unique_grafana_name = "juju_{}_{}_{}_{}".format(
+            self._charm.model.name,
+            self._charm.model.uuid,
+            self._charm.model.app.name,
+            self._charm.model.unit.name.split("/")[1],  # type: ignore
+        )
+
+        rel.data[self._charm.app]["grafana_uid"] = unique_grafana_name
         rel.data[self._charm.app]["datasource_uids"] = json.dumps(uids)
 
     def _get_source_config(self, rel: Relation):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,12 @@
 ops
-cosl>=0.0.43
+cosl>=0.0.47
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane
+
+# lib/charms/tls_certificates_interface/v3/tls_certificates.py
+jsonschema
+cryptography
 
 # lib/charms/tempo_k8s/v1/charm_tracing.py
 opentelemetry-exporter-otlp-proto-http

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.loki_k8s.v1.loki_push_api import LokiPushApiProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
-from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
 from cosl.interfaces.datasource_exchange import DatasourceDict
 from ops.model import ModelError
@@ -112,6 +112,29 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
         # do this regardless of what event we are processing
         self._reconcile()
+
+        ######################################
+        # === EVENT HANDLER REGISTRATION === #
+        ######################################
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+
+    ##########################
+    # === EVENT HANDLERS === #
+    ##########################
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        """Log the obtained ingress address.
+
+        This event refreshes the PrometheusRemoteWriteProvider address.
+        """
+        logger.info("Ingress for app ready on '%s'", event.url)
+
+    def _on_ingress_revoked(self, _) -> None:
+        """Log the ingress address being revoked.
+
+        This event refreshes the PrometheusRemoteWriteProvider address.
+        """
+        logger.info("Ingress for app revoked")
 
     ######################
     # === PROPERTIES === #

--- a/src/charm.py
+++ b/src/charm.py
@@ -255,4 +255,4 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    ops.main.main(LokiCoordinatorK8SOperatorCharm)
+    ops.main(LokiCoordinatorK8SOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,6 +26,7 @@ from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
 from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
+from cosl.interfaces.datasource_exchange import DatasourceDict
 from ops.model import ModelError
 from ops.pebble import Error as PebbleError
 
@@ -77,6 +78,8 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "charm-tracing": "charm-tracing",
                 "workload-tracing": "workload-tracing",
                 "s3": "s3",
+                "send-datasource": "send-datasource",
+                "receive-datasource": None,
             },
             nginx_config=NginxConfig().config,
             workers_config=LokiConfig(
@@ -109,6 +112,9 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
         if self._nginx_container.can_connect():
             self._set_alerts()
+
+        # do this regardless of what event we are processing
+        self._reconcile()
 
         ######################################
         # === EVENT HANDLER REGISTRATION === #
@@ -207,7 +213,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _ensure_lokitool(self):
         """Copy the `lokitool` binary to the workload container."""
-        if self._nginx_container.exists("/usr/bin/mimirtool"):
+        if self._nginx_container.exists("/usr/bin/lokitool"):
             return
         with open("lokitool", "rb") as f:
             self._nginx_container.push("/usr/bin/lokitool", source=f, permissions=0o744)
@@ -252,6 +258,30 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                 logger.info(f"lokitool: {lokitool_output.stdout.read().strip()}")
             if lokitool_output.stderr:
                 logger.error(f"lokitool (err): {lokitool_output.stderr.read().strip()}")
+
+    def _update_datasource_exchange(self) -> None:
+        """Update the grafana-datasource-exchange relations."""
+        if not self.unit.is_leader():
+            return
+
+        # we might have multiple grafana-source relations, this method collects them all and returns a mapping from
+        # the `grafana_uid` to the contents of the `datasource_uids` field
+        # for simplicity, we assume that we're sending the same data to different grafanas.
+        # read more in https://discourse.charmhub.io/t/tempo-ha-docs-correlating-traces-metrics-logs/16116
+        grafana_uids_to_units_to_uids = self.grafana_source.get_source_uids()
+        raw_datasources: List[DatasourceDict] = []
+
+        for grafana_uid, ds_uids in grafana_uids_to_units_to_uids.items():
+            for _, ds_uid in ds_uids.items():
+                raw_datasources.append({"type": "loki", "uid": ds_uid, "grafana_uid": grafana_uid})
+        self.coordinator.datasource_exchange.publish(datasources=raw_datasources)
+
+    def _reconcile(self):
+        # This method contains unconditional update logic, i.e. logic that should be executed
+        # regardless of the event we are processing.
+        # reason is, if we miss these events because our coordinator cannot process events (inconsistent status),
+        # we need to 'remember' to run this logic as soon as we become ready, which is hard and error-prone
+        self._update_datasource_exchange()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -157,6 +157,8 @@ async def deploy_tempo_cluster(ops_test: OpsTest):
             status="active",
             timeout=2000,
             idle_period=30,
+            # TODO: remove when https://github.com/canonical/tempo-coordinator-k8s-operator/issues/90 is fixed
+            raise_on_error=False,
         )
 
 

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,140 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+import socket
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from cosl.coordinated_workers.interface import (
+    ClusterRequirerAppData,
+    ClusterRequirerUnitData,
+)
+from interface_tester import InterfaceTester
+from ops import ActiveStatus
+from ops.pebble import Layer
+from scenario import Relation
+from scenario.state import Container, Exec, State
+
+from charm import LokiCoordinatorK8SOperatorCharm
+
+nginx_container = Container(
+    name="nginx",
+    can_connect=True,
+    layers={
+        "foo": Layer(
+            {
+                "summary": "foo",
+                "description": "bar",
+                "services": {
+                    "nginx": {
+                        "startup": "enabled",
+                        "current": "active",
+                        "name": "nginx",
+                    }
+                },
+                "checks": {},
+            }
+        )
+    },
+    execs={
+        Exec(
+            [
+                "lokitool",
+                "rules",
+                "sync",
+                f"--address=http://{socket.getfqdn()}:8080",
+                "--id=fake",
+            ],
+            return_code=0,
+        )
+    },
+)
+
+nginx_prometheus_exporter_container = Container(
+    name="nginx-prometheus-exporter",
+    can_connect=True,
+)
+
+s3_relation = Relation(
+    "s3",
+    remote_app_data={
+        "access-key": "key",
+        "bucket": "loki",
+        "endpoint": "http://1.2.3.4:9000",
+        "secret-key": "soverysecret",
+    },
+)
+cluster_relation = Relation(
+    "loki-cluster",
+    remote_app_data=ClusterRequirerAppData(role="all").dump(),
+    remote_units_data={
+        0: ClusterRequirerUnitData(
+            address="http://example.com",
+            juju_topology={"application": "app", "unit": "unit", "charm_name": "charmname"},
+        ).dump()
+    },
+)
+
+grafana_source_relation = Relation(
+    "grafana-source",
+    remote_app_data={"datasources": json.dumps({"loki/0": {"type": "loki", "uid": "01234"}})},
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_all():
+    with ExitStack() as stack:
+        stack.enter_context(patch("lightkube.core.client.GenericSyncClient"))
+        stack.enter_context(
+            patch.multiple(
+                "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=MagicMock(return_value=True),
+                get_status=lambda _: ActiveStatus(""),
+            )
+        )
+        stack.enter_context(charm_tracing_disabled())
+        stack.enter_context(
+            patch(
+                "charm.LokiCoordinatorK8SOperatorCharm._ensure_lokitool",
+                MagicMock(return_value=None),
+            )
+        )
+        yield
+
+
+# Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
+# this fixture is used by the test runner of charm-relation-interfaces to test loki's compliance
+# with the interface specifications.
+# DO NOT MOVE OR RENAME THIS FIXTURE! If you need to, you'll need to open a PR on
+# https://github.com/canonical/charm-relation-interfaces and change loki's test configuration
+# to include the new identifier/location.
+
+
+@pytest.fixture
+def grafana_datasource_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=LokiCoordinatorK8SOperatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[s3_relation, cluster_relation],
+        ),
+    )
+    yield interface_tester
+
+
+@pytest.fixture
+def grafana_datasource_exchange_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=LokiCoordinatorK8SOperatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[s3_relation, cluster_relation, grafana_source_relation],
+        ),
+    )
+    yield interface_tester

--- a/tests/interface/test_grafana_datasource_exchange.py
+++ b/tests/interface/test_grafana_datasource_exchange.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_exchange_v0_interface(
+    grafana_datasource_exchange_tester: InterfaceTester,
+):
+    grafana_datasource_exchange_tester.configure(
+        interface_name="grafana_datasource_exchange",
+        interface_version=0,
+    )
+    grafana_datasource_exchange_tester.run()

--- a/tests/interface/test_grafana_source.py
+++ b/tests/interface/test_grafana_source.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_v0_interface(grafana_datasource_tester: InterfaceTester):
+    grafana_datasource_tester.configure(
+        interface_name="grafana_datasource",
+        interface_version=0,
+    )
+    grafana_datasource_tester.run()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,0 +1,104 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from ops import ActiveStatus
+from scenario import Container, Context, Exec, Relation
+
+from charm import LokiCoordinatorK8SOperatorCharm
+
+
+@pytest.fixture(autouse=True, scope="session")
+def disable_charm_tracing():
+    with charm_tracing_disabled():
+        yield
+
+
+@pytest.fixture
+def loki_charm(tmp_path):
+    with patch("lightkube.core.client.GenericSyncClient"):
+        with patch.multiple(
+            "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            get_status=lambda _: ActiveStatus(""),
+            is_ready=lambda _: True,
+        ):
+            with patch(
+                "charm.LokiCoordinatorK8SOperatorCharm._ensure_lokitool",
+                MagicMock(return_value=None),
+            ):
+                yield LokiCoordinatorK8SOperatorCharm
+
+
+@pytest.fixture(scope="function")
+def context(loki_charm):
+    return Context(charm_type=loki_charm)
+
+
+@pytest.fixture(scope="function")
+def nginx_container():
+    return Container(
+        "nginx",
+        can_connect=True,
+        execs={
+            Exec(
+                [
+                    "lokitool",
+                    "rules",
+                    "sync",
+                    f"--address=http://{socket.getfqdn()}:8080",
+                    "--id=fake",
+                ],
+                return_code=0,
+            )
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def nginx_prometheus_exporter_container():
+    return Container(
+        "nginx-prometheus-exporter",
+        can_connect=True,
+    )
+
+
+@pytest.fixture(scope="function")
+def s3_config():
+    return {
+        "access-key": "key",
+        "bucket": "loki",
+        "endpoint": "http://1.2.3.4:9000",
+        "secret-key": "soverysecret",
+    }
+
+
+@pytest.fixture(scope="function")
+def s3(s3_config):
+    return Relation(
+        "s3",
+        remote_app_data=s3_config,
+        local_unit_data={"bucket": "loki"},
+    )
+
+
+@pytest.fixture(scope="function")
+def all_worker():
+    return Relation(
+        "loki-cluster",
+        remote_app_data={"role": '"all"'},
+        remote_units_data={
+            0: {
+                "address": json.dumps("localhost"),
+                "juju_topology": json.dumps(
+                    {"application": "worker", "unit": "worker/0", "charm_name": "loki"}
+                ),
+            }
+        },
+    )

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+import scenario
+from cosl.interfaces.datasource_exchange import (
+    DatasourceExchange,
+    DSExchangeAppData,
+    GrafanaDatasource,
+)
+from scenario import Relation, State
+
+
+def test_datasource_send(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # GIVEN a regular HA deployment and two ds_exchange integrations with a tempo and a mimir
+    ds_tempo = [
+        {"type": "tempo", "uid": "3", "grafana_uid": "4"},
+    ]
+
+    ds_mimir = [
+        {"type": "prometheus", "uid": "8", "grafana_uid": "9"},
+    ]
+
+    mimir_dsx = Relation(
+        "send-datasource",
+        remote_app_data=DSExchangeAppData(
+            datasources=json.dumps(sorted(ds_mimir, key=lambda raw_ds: raw_ds["uid"]))
+        ).dump(),
+    )
+    tempo_dsx = Relation(
+        "send-datasource",
+        remote_app_data=DSExchangeAppData(
+            datasources=json.dumps(sorted(ds_tempo, key=lambda raw_ds: raw_ds["uid"]))
+        ).dump(),
+    )
+
+    ds = Relation(
+        "grafana-source",
+        remote_app_data={
+            "grafana_uid": "foo-something-bars",
+            "datasource_uids": json.dumps({"loki/0": "1234"}),
+        },
+    )
+
+    state_in = State(
+        relations=[
+            s3,
+            all_worker,
+            ds,
+            mimir_dsx,
+            tempo_dsx,
+        ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        unit_status=scenario.ActiveStatus(),
+        leader=True,
+    )
+
+    # WHEN we receive any event
+    with context(context.on.update_status(), state_in) as mgr:
+        charm = mgr.charm
+        # THEN we can find all received datasource uids in the coordinator
+        dsx: DatasourceExchange = charm.coordinator.datasource_exchange
+        received = dsx.received_datasources
+        assert received == (
+            GrafanaDatasource(type="tempo", uid="3", grafana_uid="4"),
+            GrafanaDatasource(type="prometheus", uid="8", grafana_uid="9"),
+        )
+        state_out = mgr.run()
+
+    # AND THEN we forward our own datasource information to mimir and loki
+    assert state_out.unit_status.name == "active"
+    published_dsx_mimir = state_out.get_relation(mimir_dsx.id).local_app_data
+    published_dsx_tempo = state_out.get_relation(tempo_dsx.id).local_app_data
+    assert published_dsx_tempo == published_dsx_mimir
+    assert json.loads(published_dsx_tempo["datasources"])[0] == {
+        "type": "loki",
+        "uid": "1234",
+        "grafana_uid": "foo-something-bars",
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ deps =
     pytest
     coverage[toml]
     deepdiff
+    ops[testing]>=2.17
     -r{toxinidir}/requirements.txt
     
     # Binary deps from from charmcraft.yaml
@@ -69,17 +70,8 @@ commands =
                  -s \
                  {[vars]tst_path}unit \
                  {posargs}
-    coverage report
 
-[testenv:scenario]
-description = Run scenario tests
-deps =
-    pytest
-    coverage[toml]
-    ops[testing]>=2.17
-    -r{toxinidir}/requirements.txt
-commands =
-    coverage run --source={[vars]src_path} \
+    coverage run --source={[vars]src_path} --append \
                  -m pytest \
                  --tb native \
                  -v \
@@ -87,6 +79,7 @@ commands =
                  {[vars]tst_path}scenario \
                  {posargs}
     coverage report
+
 
 [testenv:integration]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -76,17 +76,17 @@ description = Run scenario tests
 deps =
     pytest
     coverage[toml]
-    ops-scenario>=3.0
+    ops[testing]>=2.17
     -r{toxinidir}/requirements.txt
 commands =
-    ; coverage run --source={[vars]src_path} \
-    ;              -m pytest \
-    ;              --tb native \
-    ;              -v \
-    ;              -s \
-    ;              {[vars]tst_path}scenario \
-    ;              {posargs}
-    ; coverage report
+    coverage run --source={[vars]src_path} \
+                 -m pytest \
+                 --tb native \
+                 -v \
+                 -s \
+                 {[vars]tst_path}scenario \
+                 {posargs}
+    coverage report
 
 [testenv:integration]
 description = Run integration tests
@@ -104,3 +104,12 @@ commands =
            --log-cli-level=INFO \
            {[vars]tst_path}integration \
            {posargs}
+
+[testenv:interface]
+description = Run interface tests
+deps =
+    pytest
+    pytest-interface-tester > 2.0.0
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native {[vars]tst_path}/interface --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Issue
Add a `send-datasource` endpoint to exchange datasource UIDs with other COS components.

## Testing Instructions
1. Deploy Loki HA
2. Deploy `grafana-k8s`
3. Deploy Tempo HA
4. Integrate `tempo` and `grafana` over `grafana_datasource`
5. Integrate `loki` and `grafana` over `grafana_datasource`
6. Integrate `loki` and `tempo` over `grafana_datasource_exchange`
7. `jhack show-relation loki tempo` and observe the datasource UID of `loki` shared to `tempo` 

## Drive-bys
- Add interface and scenario tests
- Fix typo `mimirtool` to `lokitool`