### PR TITLE
Enable/Disable IPv6-related nginx config

### DIFF
--- a/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -1,0 +1,164 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm for providing services catalogues to bundles or sets of charms."""
+
+import ipaddress
+import logging
+import socket
+from typing import Optional
+
+from ops.charm import CharmBase
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+
+LIBID = "fa28b361293b46668bcd1f209ada6983"
+LIBAPI = 1
+LIBPATCH = 0
+
+DEFAULT_RELATION_NAME = "catalogue"
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogueItem:
+    """`CatalogueItem` represents an application entry sent to a catalogue.
+
+    The icon is an iconify mdi string; see https://icon-sets.iconify.design/mdi.
+    """
+
+    def __init__(self, name: str, url: str, icon: str, description: str = ""):
+        self.name = name
+        self.url = url
+        self.icon = icon
+        self.description = description
+
+
+class CatalogueConsumer(Object):
+    """`CatalogueConsumer` is used to send over a `CatalogueItem`."""
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        item: Optional[CatalogueItem] = None,
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._item = item
+
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_changed)
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_created, self._on_relation_changed)
+
+    def _on_relation_changed(self, _):
+        self._update_relation_data()
+
+    def _update_relation_data(self):
+        if not self._charm.unit.is_leader():
+            return
+
+        if not self._item:
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.model.app]["name"] = self._item.name
+            relation.data[self._charm.model.app]["description"] = self._item.description
+            relation.data[self._charm.model.app]["url"] = self.unit_address(relation)
+            relation.data[self._charm.model.app]["icon"] = self._item.icon
+
+    def update_item(self, item: CatalogueItem):
+        """Update the catalogue item."""
+        self._item = item
+        self._update_relation_data()
+
+    def unit_address(self, relation):
+        """The unit address of the consumer, on which it is reachable.
+
+        Requires ingress to be connected for it to be routable.
+        """
+        if self._item and self._item.url:
+            return self._item.url
+
+        unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
+        if self._is_valid_unit_address(unit_ip):
+            return unit_ip
+
+        return socket.getfqdn()
+
+    def _is_valid_unit_address(self, address: str) -> bool:
+        """Validate a unit address.
+
+        At present only IP address validation is supported, but
+        this may be extended to DNS addresses also, as needed.
+
+        Args:
+            address: a string representing a unit address
+        """
+        try:
+            _ = ipaddress.ip_address(address)
+        except ValueError:
+            return False
+
+        return True
+
+
+class CatalogueItemsChangedEvent(EventBase):
+    """Event emitted when the catalogue entries change."""
+
+    def __init__(self, handle, items):
+        super().__init__(handle)
+        self.items = items
+
+    def snapshot(self):
+        """Save catalogue entries information."""
+        return {"items": self.items}
+
+    def restore(self, snapshot):
+        """Restore catalogue entries information."""
+        self.items = snapshot["items"]
+
+
+class CatalogueEvents(ObjectEvents):
+    """Events raised by `CatalogueConsumer`."""
+
+    items_changed = EventSource(CatalogueItemsChangedEvent)
+
+
+class CatalogueProvider(Object):
+    """`CatalogueProvider` is the side of the relation that serves the actual service catalogue."""
+
+    on = CatalogueEvents()  # pyright: ignore
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_broken)
+
+    def _on_relation_broken(self, event):
+        self.on.items_changed.emit(items=self.items)  # pyright: ignore
+
+    def _on_relation_changed(self, event):
+        self.on.items_changed.emit(items=self.items)  # pyright: ignore
+
+    @property
+    def items(self):
+        """A list of apps sent over relation data."""
+        return [
+            {
+                "name": relation.data[relation.app].get("name", ""),
+                "url": relation.data[relation.app].get("url", ""),
+                "icon": relation.data[relation.app].get("icon", ""),
+                "description": relation.data[relation.app].get("description", ""),
+            }
+            for relation in self._charm.model.relations[self._relation_name]
+            if relation.app and relation.units
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops
-cosl>=0.0.47
+cosl>=0.0.55
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,6 +80,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "s3": "s3",
                 "send-datasource": "send-datasource",
                 "receive-datasource": None,
+                "catalogue": None,
             },
             nginx_config=NginxConfig().config,
             workers_config=LokiConfig(

--- a/src/charm.py
+++ b/src/charm.py
@@ -206,10 +206,11 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _ensure_lokitool(self):
         """Copy the `lokitool` binary to the workload container."""
-        if self._nginx_container.exists("/usr/bin/lokitool"):
-            return
-        with open("lokitool", "rb") as f:
-            self._nginx_container.push("/usr/bin/lokitool", source=f, permissions=0o744)
+        if self._nginx_container.can_connect():
+            if self._nginx_container.exists("/usr/bin/lokitool"):
+                return
+            with open("lokitool", "rb") as f:
+                self._nginx_container.push("/usr/bin/lokitool", source=f, permissions=0o744)
 
     def _set_alerts(self):
         """Create alert rule files for all Loki consumers."""

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -343,11 +343,7 @@ class NginxConfig:
         return directives
 
     def _listen_args(self, port: int, ipv6: bool, ssl: bool) -> List[str]:
-        args = []
-        if ipv6:
-            args.append(f"[::]:{port}")
-        else:
-            args.append(f"{port}")
+        args = [f"[::]:{port}" if ipv6 else f"{port}"]
         if ssl:
             args.append("ssl")
         return args

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import crossplane
 from cosl.coordinated_workers.coordinator import Coordinator
-from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH
+from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH, is_ipv6_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +144,7 @@ class NginxConfig:
 
     def __init__(self):
         self.dns_IP_address = _get_dns_ip_address()
+        self.ipv6_enabled = is_ipv6_enabled()
 
     def config(self, coordinator: Coordinator) -> str:
         """Build and return the Nginx configuration."""
@@ -301,8 +302,7 @@ class NginxConfig:
                 "directive": "server",
                 "args": [],
                 "block": [
-                    {"directive": "listen", "args": ["443", "ssl"]},
-                    {"directive": "listen", "args": ["[::]:443", "ssl"]},
+                    *self._listen(443, ssl=True),
                     *self._basic_auth(auth_enabled),
                     {
                         "directive": "proxy_set_header",
@@ -325,8 +325,7 @@ class NginxConfig:
             "directive": "server",
             "args": [],
             "block": [
-                {"directive": "listen", "args": [f"{nginx_port}"]},
-                {"directive": "listen", "args": [f"[::]:{nginx_port}"]},
+                *self._listen(nginx_port, ssl=False),
                 *self._basic_auth(auth_enabled),
                 {
                     "directive": "proxy_set_header",
@@ -336,6 +335,23 @@ class NginxConfig:
                 *self._locations(addresses_by_role),
             ],
         }
+
+    def _listen(self, port: int, ssl: bool) -> List[Dict[str, Any]]:
+        directives = []
+        directives.append({"directive": "listen", "args": self._listen_args(port, False, ssl)})
+        if self.ipv6_enabled:
+            directives.append({"directive": "listen", "args": self._listen_args(port, True, ssl)})
+        return directives
+
+    def _listen_args(self, port: int, ipv6: bool, ssl: bool) -> List[str]:
+        args = []
+        if ipv6:
+            args.append(f"[::]:{port}")
+        else:
+            args.append(f"{port}")
+        if ssl:
+            args.append("ssl")
+        return args
 
 
 def _get_dns_ip_address():

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -337,8 +337,7 @@ class NginxConfig:
         }
 
     def _listen(self, port: int, ssl: bool) -> List[Dict[str, Any]]:
-        directives = []
-        directives.append({"directive": "listen", "args": self._listen_args(port, False, ssl)})
+        directives = [{"directive": "listen", "args": self._listen_args(port, False, ssl)}]
         if self.ipv6_enabled:
             directives.append({"directive": "listen", "args": self._listen_args(port, True, ssl)})
         return directives

--- a/tests/unit/test_nginx_config.py
+++ b/tests/unit/test_nginx_config.py
@@ -99,8 +99,8 @@ def test_servers_config(ipv6, tls):
     ipv4_args = ["443", "ssl"] if tls else [f"{port}"]
     assert {"directive": "listen", "args": ipv4_args} in server_config["block"]
     ipv6_args = ["[::]:443", "ssl"] if tls else [f"[::]:{port}"]
-    assert (
-        ({"directive": "listen", "args": ipv6_args} in server_config["block"])
-        if ipv6
-        else ({"directive": "listen", "args": ipv6_args} not in server_config["block"])
-    )
+    ipv6_directive = {"directive": "listen", "args": ipv6_args}
+    if ipv6:
+        assert ipv6_directive in server_config["block"]
+    else:
+        assert ipv6_directive not in server_config["block"]

--- a/tests/unit/test_nginx_config.py
+++ b/tests/unit/test_nginx_config.py
@@ -98,6 +98,9 @@ def test_servers_config(ipv6, tls):
     )
     ipv4_args = ["443", "ssl"] if tls else [f"{port}"]
     assert {"directive": "listen", "args": ipv4_args} in server_config["block"]
-    if ipv6:
-        ipv6_args = ["[::]:443", "ssl"] if tls else [f"[::]:{port}"]
-        assert {"directive": "listen", "args": ipv6_args} in server_config["block"]
+    ipv6_args = ["[::]:443", "ssl"] if tls else [f"[::]:{port}"]
+    assert (
+        ({"directive": "listen", "args": ipv6_args} in server_config["block"])
+        if ipv6
+        else ({"directive": "listen", "args": ipv6_args} not in server_config["block"])
+    )

--- a/tests/unit/test_nginx_config.py
+++ b/tests/unit/test_nginx_config.py
@@ -1,13 +1,20 @@
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-import src.nginx_config
+from nginx_config import NginxConfig
+
+
+@contextmanager
+def mock_ipv6(enable: bool):
+    with patch("nginx_config.is_ipv6_enabled", MagicMock(return_value=enable)):
+        yield
 
 
 @pytest.fixture(scope="module")
 def nginx_config():
-    return src.nginx_config.NginxConfig()
+    return NginxConfig()
 
 
 @pytest.fixture(scope="module")
@@ -78,3 +85,19 @@ def test_upstreams_config(nginx_config, addresses_by_role):
     # TODO assert that the two are the same
     assert upstreams_config is not None
     assert expected_config is not None
+
+
+@pytest.mark.parametrize("tls", (True, False))
+@pytest.mark.parametrize("ipv6", (True, False))
+def test_servers_config(ipv6, tls):
+    port = 8080
+    with mock_ipv6(ipv6):
+        nginx = NginxConfig()
+    server_config = nginx._server(
+        server_name="test", addresses_by_role={}, nginx_port=port, tls=tls
+    )
+    ipv4_args = ["443", "ssl"] if tls else [f"{port}"]
+    assert {"directive": "listen", "args": ipv4_args} in server_config["block"]
+    if ipv6:
+        ipv6_args = ["[::]:443", "ssl"] if tls else [f"[::]:{port}"]
+        assert {"directive": "listen", "args": ipv6_args} in server_config["block"]


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/cos-lib/issues/127

## Solution
Use https://github.com/canonical/cos-lib/pull/128 utility to check if ipv6 is enabled and listen to the ipv6 addresses accordingly.

## Context
https://github.com/canonical/cos-lib/pull/128

## Testing Instructions
1. [Disable](https://www.techrepublic.com/article/how-to-disable-ipv6-through-grub-in-linux/) ipv6 on the host machine
2. Reboot your machine
3. Deploy Loki HA
4. loki coordinator should be in active/idle and if you juju ssh --container nginx tempo/0 ss -utpln, you should not see nginx listening on any ipv6 addresses.

## Drive-bys
- fetch catalogue lib, as its been added to the shared coordinator object as part of an earlier cosl release
- add a guard for intermittent Ci fails