### PR TITLE
Use dump plugin correctly

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -37,23 +37,20 @@ parts:
 
   cos-tool:
     plugin: dump
-    source: .
-    build-packages:
-      - curl
-    override-pull: |
-      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
-      chmod +x cos-tool-*
+    source: https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
+    source-type: file
+    permissions:
+      - path: cos-tool-${CRAFT_ARCH_BUILD_FOR}
+        mode: "755"
   lokitool:
     plugin: dump
-    source: .
-    build-packages:
-      - curl
-      - unzip
-    override-pull: |
-      curl -fLo lokitool.zip https://github.com/grafana/loki/releases/download/v3.2.1/lokitool-linux-${CRAFT_TARGET_ARCH}.zip
-      unzip lokitool.zip && rm lokitool.zip
-      mv lokitool-linux-${CRAFT_TARGET_ARCH} lokitool
-      chmod +x lokitool
+    source: https://github.com/grafana/loki/releases/download/v3.2.1/lokitool-linux-${CRAFT_ARCH_BUILD_FOR}.zip
+    source-type: file
+    organize:
+      lokitool-linux-${CRAFT_ARCH_BUILD_FOR}: lokitool
+    permissions:
+      - path: lokitool
+        mode: "755"
 
 containers:
   nginx:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,7 +45,7 @@ parts:
   lokitool:
     plugin: dump
     source: https://github.com/grafana/loki/releases/download/v3.2.1/lokitool-linux-${CRAFT_ARCH_BUILD_FOR}.zip
-    source-type: file
+    source-type: zip
     organize:
       lokitool-linux-${CRAFT_ARCH_BUILD_FOR}: lokitool
     permissions:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,7 +41,7 @@ parts:
     source-type: file
     permissions:
       - path: cos-tool-${CRAFT_ARCH_BUILD_FOR}
-        mode: "755"
+        mode: "500"
   lokitool:
     plugin: dump
     source: https://github.com/grafana/loki/releases/download/v3.2.1/lokitool-linux-${CRAFT_ARCH_BUILD_FOR}.zip
@@ -50,7 +50,7 @@ parts:
       lokitool-linux-${CRAFT_ARCH_BUILD_FOR}: lokitool
     permissions:
       - path: lokitool
-        mode: "755"
+        mode: "500"
 
 containers:
   nginx:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,7 +17,7 @@ from src.loki_config import (
         ({"querier": 1}, False),
         ({"distributor": 1}, False),
         ({"distributor": 1, "ingester": 1}, False),
-        ({role: 1 for role in MINIMAL_DEPLOYMENT}, True),
+        (dict.fromkeys(MINIMAL_DEPLOYMENT, 1), True),
         (RECOMMENDED_DEPLOYMENT, True),
     ),
 )
@@ -39,7 +39,7 @@ def test_coherent(mock_coordinator, roles, expected):
         ({"query-frontend": 1}, False),
         ({"distributor": 1}, False),
         ({"distributor": 1, "ingester": 1}, False),
-        ({role: 1 for role in MINIMAL_DEPLOYMENT}, False),
+        (dict.fromkeys(MINIMAL_DEPLOYMENT, 1), False),
         (RECOMMENDED_DEPLOYMENT, True),
     ),
 )


### PR DESCRIPTION
## Issue
Currently we use the dump plugin incorrectly for cos-tool and lokitool.


## Solution
Use the dump plugin correctly.


## Context
https://github.com/canonical/grafana-agent-operator/pull/266