### PR TITLE
Drop 22.04 from charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,7 +18,6 @@ assumes:
   - juju >= 3.4.5
 
 platforms:
-  ubuntu@22.04:amd64:
   ubuntu@24.04:amd64:
 
 parts:


### PR DESCRIPTION
## Issue
This k8s charm doesn't need multiple bases for the charm container.


## Solution
Drop 22.04.

