### PR TITLE
fix: add tests for resolv.conf in nginx resolver config

### DIFF
--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -11,6 +11,7 @@ from cosl.coordinated_workers.coordinator import Coordinator
 from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH, is_ipv6_enabled
 
 logger = logging.getLogger(__name__)
+RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 LOKI_PORT = 3100
 
@@ -351,7 +352,7 @@ class NginxConfig:
 
 def _get_dns_ip_address():
     """Obtain DNS ip address from /etc/resolv.conf."""
-    resolv = Path("/etc/resolv.conf").read_text()
+    resolv = Path(RESOLV_CONF_PATH).read_text()
     for line in resolv.splitlines():
         if line.startswith("nameserver"):
             # assume there's only one

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -259,15 +259,17 @@ class NginxConfig:
                         #     "directive": "zone",
                         #     "args": [f"{role}_zone", "64k"],
                         # },
-                        {
-                            "directive": "server",
-                            "args": [
-                                f"{addr}:{worker_port}",
-                                # TODO: uncomment the below arg when nginx version >= 1.27.3
-                                #  "resolve"
-                            ],
-                        }
-                        for addr in addresses
+                        *(
+                            {
+                                "directive": "server",
+                                "args": [
+                                    f"{addr}:{worker_port}",
+                                    # TODO: uncomment the below arg when nginx version >= 1.27.3
+                                    #  "resolve"
+                                ],
+                            }
+                            for addr in addresses
+                        ),
                     ],
                 }
             )


### PR DESCRIPTION
> [!NOTE]
> This PR will be closed in favour of:
> - https://github.com/canonical/cos-lib/pull/143
> - https://github.com/canonical/loki-coordinator-k8s-operator/pull/52

## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #50 


## Solution
<!-- A summary of the solution addressing the above issue -->
Use Tempo as an example for the custom resolvers since the feature was enabled in:
- https://github.com/canonical/tempo-coordinator-k8s-operator/pull/88


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
The resolvers differ between microk8s and canonical-k8s:
microk8s -> `kube-dns.kube-system.svc.cluster.local.`
canonical-k8s -> `coredns`

### Recommendations
- Accoding to [this post](https://stackoverflow.com/a/40331256/3516684), Nginx has implemented its own internal non-blocking resolver. We also need the features: config file contains variables in domain names, track IP changes, and Nginx reload.
From [nginx docs](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream)
1. Use `Syntax:	resolver address ... [valid=time]` to shorten the `valid` attribute on the resolver to something like `5s` as by default it'll use the default DNS TTL which might be large. In the backend for reverse proxy you usually want to be reactive to change
2. Shorten the deafult DNS timeout (`30s`, huge when requests are pending to be proxied) with a `resolver_timeout` to something like `5s`.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. `tox -e unit -- tests/unit/test_nginx_config.py`
- [ ] @vishvikkrishnan to deploy on canonical-k8s and see if the custom resolver overwrites the nginx config to `coredns`

