### PR TITLE
fix: ingress databag when TLS information exists

### DIFF
--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,3 @@
+def get_relation_data(relations, endpoint, key):
+    """Retrieve the value for a given key from the local_app_data of a relation with the specified endpoint."""
+    return next((r.local_app_data[key] for r in relations if r.endpoint == endpoint), None)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import MagicMock
+
+import scenario
+from helpers import get_relation_data
+from scenario import Relation, State
+
+from charm import NGINX_PORT, NGINX_TLS_PORT
+
+
+def test_ingress_tls(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # GIVEN Loki is related over the ingress and certificates endpoints
+    ingress = Relation("ingress")
+    certificates = Relation("certificates")
+
+    state_in = State(
+        relations=[
+            s3,
+            all_worker,
+            ingress,
+            certificates,
+        ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        unit_status=scenario.ActiveStatus(),
+        leader=True,
+    )
+
+    # WHEN TLS is not yet available
+    with context(context.on.relation_joined(ingress), state_in) as mgr:
+        charm = mgr.charm
+        state_out = mgr.run()
+
+        # THEN there are no certificates on disk
+        assert not charm.coordinator.nginx.are_certificates_on_disk
+
+        # AND Loki publishes its Nginx non-TLS port in the ingress databag
+        assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_PORT)
+
+    # AND WHEN the ingress databag is updated
+    with context(context.on.relation_changed(ingress), state_in) as mgr:
+        charm = mgr.charm
+        charm.coordinator.nginx = MagicMock()
+        # AND TLS was/is available
+        charm.coordinator.nginx.are_certificates_on_disk = True
+
+        state_out = mgr.run()
+
+        # THEN Loki publishes its Nginx TLS port in the ingress databag
+        assert get_relation_data(state_out.relations, "ingress", "scheme") == '"https"'
+        assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_TLS_PORT)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes:
- https://github.com/canonical/loki-coordinator-k8s-operator/issues/68

## Solution
<!-- A summary of the solution addressing the above issue -->
- Fix the hardcoded HTTP port in the `internal_url`
- Update the port in the Loki coordinator constructor for the `IngressPerApp` class
- Add scenario tests for databag contents with and without TLS configured.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
When we switch to the HTTPS scheme due to TLS, we keep the non-TLS port, causing the SSL handshake fail. This is determined by the underlying Nginx config which exposes 8080 as HTTP and 443 as HTTPS

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e integration -- tests/unit/test_tls.py`

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
