### PR TITLE
feat: Grafana-source unit data ingress deduplication

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -105,7 +105,13 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             source_url=self.external_url,
             extra_fields={"httpHeaderName1": "X-Scope-OrgID"},
             secure_extra_fields={"httpHeaderValue1": "anonymous"},
-            refresh_event=[self.coordinator.cluster.on.changed],
+            refresh_event=[
+                self.coordinator.cluster.on.changed,
+                self.on[self.coordinator._certificates.relationship_name].relation_changed,
+                self.ingress.on.ready,
+                self.ingress.on.revoked,
+            ],
+            is_ingress_per_app=self.ingress.is_ready(),
         )
 
         external_url = urlparse(self.external_url)

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -32,7 +32,7 @@ async def test_build_and_deploy(ops_test: OpsTest, loki_charm: str, cos_channel)
     """Build the charm-under-test and deploy it together with related charms."""
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
-        ops_test.model.deploy(loki_charm, "loki", resources=charm_resources(), trust=True),
+        ops_test.model.deploy(loki_charm, "loki", resources=charm_resources(), num_units=3, trust=True),
         ops_test.model.deploy("prometheus-k8s", "prometheus", channel=cos_channel, trust=True),
         ops_test.model.deploy("loki-k8s", "loki-mono", channel=cos_channel, trust=True),
         ops_test.model.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True),
@@ -134,7 +134,9 @@ async def test_grafana_source(ops_test: OpsTest):
     """Test the grafana-source integration, by checking that Loki appears in the Datasources."""
     assert ops_test.model is not None
     datasources = await get_grafana_datasources(ops_test)
-    assert "loki" in datasources[0]["name"]
+    loki_datasources = ["loki" in d["name"] for d in datasources]
+    assert any(loki_datasources)
+    assert len(loki_datasources) == 1
 
 
 @retry(wait=wait_fixed(10), stop=stop_after_attempt(6))


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Only provide one Grafana data source (from the leader) when ingressed, otherwise each unit provides one.

## Solution
<!-- A summary of the solution addressing the above issue -->
Tandem PR:
- https://github.com/canonical/grafana-k8s-operator/pull/427

Related:
- https://github.com/canonical/mimir-coordinator-k8s-operator/pull/161

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- https://github.com/canonical/grafana-k8s-operator/pull/427#issuecomment-3090584719
