### PR TITLE
fix: update loki endpoints

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,6 @@ NGINX_PORT = NginxHelper._nginx_port
 NGINX_TLS_PORT = NginxHelper._nginx_tls_port
 
 
-
 class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
     """Charm the service."""
 
@@ -124,6 +123,7 @@ class LokiCoordinatorK8SOperatorCharm(ops.CharmBase):
             scheme=external_url.scheme,
             path=f"{external_url.path}/loki/api/v1/push",
         )
+        self.loki_provider.update_endpoint(url=self.external_url)
 
         # do this regardless of what event we are processing
         self._reconcile()


### PR DESCRIPTION
## Issue
Our Loki library always uses the internal URL whenever updating the relation data endpoint. We never noticed because the Loki monolithic charm (loki-k8s) is calling `loki_provider.update_endpoints()` manually, instead of letting the library object handle relation data.


## Solution
Call `update_endpoints()` in this charm as well. I will open an issue on Loki to remind us to move this behavior into the library itself.

Before:
<img width="1104" height="181" alt="image" src="https://github.com/user-attachments/assets/04edd7c5-2926-4327-a218-286cb82382b6" />


After:
<img width="903" height="250" alt="image" src="https://github.com/user-attachments/assets/7c8f4364-3ceb-443d-b3aa-1bf271608377" />
