### PR TITLE
chore: pin TF Juju provider to version = "< 1.0.0"

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,38 +2,47 @@
 
 This is a Terraform module facilitating the deployment of loki-coordinator-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
-This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
-## API
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | < 1.0.0 |
 
-### Inputs
-The module offers the following configurable inputs:
+## Providers
 
-| Name | Type | Description | Default |
-| - | - | - | - |
-| `app_name`| string | Name to give the deployed application | loki |
-| `channel`| string | Channel that the charm is deployed from |  |
-| `config`| map(string) | Map of the charm configuration options | {} |
-| `constraints`| string | String listing constraints for this application | arch=amd64 |
-| `model`| string | Reference to an existing model resource or data source for the model to deploy to |  |
-| `revision`| number | Revision number of the charm |  |
-| `storage_directives`| map(string) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju. | {} |
-| `units`| number | Unit count/scale | 1 |
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | < 1.0.0 |
 
-### Outputs
-Upon application, the module exports the following outputs:
+## Modules
 
-| Name | Type | Description |
-| - | - | - |
-| `app_name`| string | Name of the deployed application |
-| `endpoints`| map(string) | Map of all `provides` and `requires` endpoints |
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"loki"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+<!-- END_TF_DOCS -->
 
 ## Usage
 
 > [!NOTE]
 > This module is intended to be used only in conjunction with its counterpart, [Loki worker module](https://github.com/canonical/loki-worker-k8s-operator) and, when deployed in isolation, is not functional. 
 > For the Loki HA solution module deployment, check [Loki HA module](https://github.com/canonical/observability)
-
-### Basic usage

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = "< 1.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR pins the TF provider for the root module and submodules to `version = "< 1.0.0"` so that we can tag this repo for users to always be able to source our modules for TF Juju provider `< v1`. See [this tracking issue](https://github.com/canonical/observability-stack/issues/135) for details.