### PR TITLE
chore: fix ci

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "~=3.10"
 dependencies = [
   "coordinated-workers",
   "charmed-service-mesh-helpers>=0.2.0",
-  "lightkube-extensions==0.3.0",
+  "lightkube-extensions",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -1010,7 +1010,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "deepdiff", marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'" },
-    { name = "lightkube-extensions", specifier = "==0.3.0" },
+    { name = "lightkube-extensions" },
     { name = "minio", marker = "extra == 'dev'" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Due to an upgrade in the `lightkube-extensions` service mesh package on Git, some of the imports in the new version of `istio_beacon_k8s/v0/service_mesh` have been failing. These rely on the previously mentioned package to be >= v0.3.0.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR fixes the issue by doing bumping `lightkube-extensions` to `v0.3.0`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
