### PR TITLE
feat: Manually trigger release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: Release Charm
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -11,4 +12,4 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v1
     secrets: inherit
     with:
-      default-track: 2
+      default-track: dev


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We want to be able to release charms manually with the release charm workflow in `track/2`